### PR TITLE
fix: added padding to Item ScrollView so that notch does not cover it

### DIFF
--- a/HelloWorld/app/Receipt_Room_Page/index.tsx
+++ b/HelloWorld/app/Receipt_Room_Page/index.tsx
@@ -159,6 +159,7 @@ const createStyles = (colors: NativeThemeColorType) =>
     container: {
       flex: 1,
       backgroundColor: colors.background,
+      paddingTop: 60,
     },
     topBar: {
       backgroundColor: colors.card,


### PR DESCRIPTION
The Item ScrollView on the Receipt Room Page was previously partially cut off by the notch on ios. This fix adds some padding to the top of the page to prevent any elements from touching the notch.

Closes #114 