### PR TITLE
reverted back import statement 

### DIFF
--- a/frontend/shared/src/components/ReceiptItem.tsx
+++ b/frontend/shared/src/components/ReceiptItem.tsx
@@ -16,8 +16,8 @@ import {
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 
-import { ReceiptItemData } from '@/types';
-import UserTag from '@/components/UserTag';
+import { ReceiptItemData } from '@shared/types';
+import UserTag from '@shared/components/UserTag';
 
 export const USER_COLORS = [
   '#60a5fa', // blue-400


### PR DESCRIPTION
I reverted back the import statement for types and UserTag in frontend\shared\src\components\ReceiptItem.tsx  (changed @ back to @shared). The previous changes caused the app to not build.

closes #183 