### PR TITLE
fix: receipt page --> your items page routing fixed

### DIFF
--- a/frontend/apps/mobile/app/receipt-room/index.tsx
+++ b/frontend/apps/mobile/app/receipt-room/index.tsx
@@ -287,7 +287,7 @@ export default function ReceiptRoomScreen() {
                 }}
                 goToYourItemsPage={() =>
                   router.push({
-                    pathname: '../Your_Items_Page',
+                    pathname: '../items',
                     params: {
                       items: (() => {
                         let senditems = receiptItems.items.filter((item) =>


### PR DESCRIPTION
Changed pathname from `../Your_Items_Page` to `../items` to match the new folder name

closes #184