### PR TITLE
fix: update global.css path

### DIFF
--- a/frontend/apps/mobile/metro.config.js
+++ b/frontend/apps/mobile/metro.config.js
@@ -6,6 +6,6 @@ let config = getDefaultConfig(__dirname);
 config.resolver.sourceExts = ['ts', 'tsx', 'js', 'jsx', 'json'];
 config.watchFolders = [__dirname, path.resolve(__dirname, '../../shared')];
 /**@ts-ignore */
-config = withNativeWind(config, { input: './global.css' });
+config = withNativeWind(config, { input: '../../shared/styles/global.css' });
 
 module.exports = config;


### PR DESCRIPTION
Currently: `config = withNativeWind(config, { input: './global.css' });`
Should be: `config = withNativeWind(config, { input: '../../shared/styles/global.css' });`

Otherwise `npm expo export` gets stuck at 0%

closes #248 