### PR TITLE
feat: web join flow and anonymous sign in

### DIFF
--- a/frontend/apps/mobile/app/qr/index.tsx
+++ b/frontend/apps/mobile/app/qr/index.tsx
@@ -14,7 +14,9 @@ export default function QRScreen() {
   const qrRef = useRef<QRCode>(null);
 
   // The URL encoded in the QR code
-  const qrData = `helloworld://Receipt_Room_Page?roomId=${roomId}`;
+  // TODO: currently using local web,
+  // will need change to vercel deployment
+  const qrData = `http://localhost:5173/join?roomId=${roomId}`;
 
   async function handleShareQRImage() {
     try {

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@eezy-receipt/shared": "*",
+    "@supabase/supabase-js": "^2.98.0",
     "@tailwindcss/vite": "^4.1.18",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/apps/web/src/main.tsx
+++ b/frontend/apps/web/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 import './index.css';
 import App from './App.tsx';
+import { AuthProvider } from './providers/AuthProvider.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/frontend/apps/web/src/pages/GroupPage.tsx
+++ b/frontend/apps/web/src/pages/GroupPage.tsx
@@ -1,9 +1,32 @@
 // TODO: implement group page
-// - require auth — redirect to login page if no session
-// - fetch receipt items
-// - render list of receipt items and participants
+// - require auth — redirect to /join if no authorized session
+// - fetch participants from backend
+// - let user select which participant they are
+// - fetch receipt items from backend
+// - replace mock data with real items
 // - allow users to claim/unclaim items
 
+import { useParams } from 'react-router';
+
+const MOCK_ITEMS = [
+  { id: '1', name: 'Burger', price: '$12.99' },
+  { id: '2', name: 'Fries', price: '$4.99' },
+  { id: '3', name: 'Soda', price: '$2.99' },
+];
+
 export default function GroupPage() {
-  return <p>GroupPage</p>;
+  const { roomId } = useParams<{ roomId: string }>();
+
+  return (
+    <div>
+      <h1>Room: {roomId}</h1>
+      <ul>
+        {MOCK_ITEMS.map((item) => (
+          <li key={item.id}>
+            {item.name} — {item.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/apps/web/src/pages/JoinPage.tsx
+++ b/frontend/apps/web/src/pages/JoinPage.tsx
@@ -1,9 +1,21 @@
-// TODO: implement join page
-// - if no id in query params (?id=<groupId>), show "Scan a QR code to join a session"
-// - if id present, call endpoint /group/join with Bearer token
-// - on success, redirect to /group/:roomId
-// - show error state if join fails
+import { useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router';
+import { useAuth } from '../providers/AuthContext';
 
 export default function JoinPage() {
-  return <p>JoinPage</p>;
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { isLoading } = useAuth();
+  const roomId = searchParams.get('roomId');
+
+  useEffect(() => {
+    if (!roomId || isLoading) return;
+
+    // TODO: call GET /group/join?group_id=<roomId> with Bearer token before navigating
+    // TODO: error states
+    navigate(`/group/${roomId}`);
+  }, [roomId, isLoading, navigate]);
+
+  if (!roomId) return <p>Scan a QR code to join a group.</p>;
+  return <p>Joining group...</p>;
 }

--- a/frontend/apps/web/src/providers/AuthContext.ts
+++ b/frontend/apps/web/src/providers/AuthContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export type AuthContextType = {
+  accessToken: string | null;
+  isLoading: boolean;
+};
+
+export const AuthContext = createContext<AuthContextType | undefined>(
+  undefined,
+);
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+}

--- a/frontend/apps/web/src/providers/AuthProvider.tsx
+++ b/frontend/apps/web/src/providers/AuthProvider.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AuthContext } from './AuthContext';
+import { supabase } from '../services/supabase';
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const initAuth = async () => {
+      try {
+        let session = (await supabase.auth.getSession()).data.session;
+        if (!session) {
+          const { data } = await supabase.auth.signInAnonymously();
+          session = data.session;
+        }
+        if (mounted) setAccessToken(session?.access_token ?? null);
+      } finally {
+        if (mounted) setIsLoading(false);
+      }
+    };
+
+    void initAuth();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) setAccessToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({ accessToken, isLoading }),
+    [accessToken, isLoading],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/frontend/apps/web/src/services/supabase.ts
+++ b/frontend/apps/web/src/services/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY in .env',
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/apps/web/vercel.json
+++ b/frontend/apps/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -98,6 +98,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@eezy-receipt/shared": "*",
+        "@supabase/supabase-js": "^2.98.0",
         "@tailwindcss/vite": "^4.1.18",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -6214,9 +6215,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.97.0.tgz",
-      "integrity": "sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.98.0.tgz",
+      "integrity": "sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6226,9 +6227,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.97.0.tgz",
-      "integrity": "sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.98.0.tgz",
+      "integrity": "sha512-N/xEyiNU5Org+d+PNCpv+TWniAXRzxIURxDYsS/m2I/sfAB/HcM9aM2Dmf5edj5oWb9GxID1OBaZ8NMmPXL+Lg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6238,9 +6239,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.97.0.tgz",
-      "integrity": "sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.98.0.tgz",
+      "integrity": "sha512-v6e9WeZuJijzUut8HyXu6gMqWFepIbaeaMIm1uKzei4yLg9bC9OtEW9O14LE/9ezqNbSAnSLO5GtOLFdm7Bpkg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -6250,9 +6251,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.97.0.tgz",
-      "integrity": "sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.98.0.tgz",
+      "integrity": "sha512-rOWt28uGyFipWOSd+n0WVMr9kUXiWaa7J4hvyLCIHjRFqWm1z9CaaKAoYyfYMC1Exn3WT8WePCgiVhlAtWC2yw==",
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.6.6",
@@ -6265,9 +6266,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.97.0.tgz",
-      "integrity": "sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.98.0.tgz",
+      "integrity": "sha512-tzr2mG+v7ILSAZSfZMSL9OPyIH4z1ikgQ8EcQTKfMRz4EwmlFt3UnJaGzSOxyvF5b+fc9So7qdSUWTqGgeLokQ==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -6278,16 +6279,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
-      "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
+      "version": "2.98.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
+      "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.97.0",
-        "@supabase/functions-js": "2.97.0",
-        "@supabase/postgrest-js": "2.97.0",
-        "@supabase/realtime-js": "2.97.0",
-        "@supabase/storage-js": "2.97.0"
+        "@supabase/auth-js": "2.98.0",
+        "@supabase/functions-js": "2.98.0",
+        "@supabase/postgrest-js": "2.98.0",
+        "@supabase/realtime-js": "2.98.0",
+        "@supabase/storage-js": "2.98.0"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Closes #279 
Closes #301 

changes
- added supabase to web. need to add keys to vercel deployment
- created auth provider context
- implemented join flow: scan qr code -> opens web app /join?roomId -> anonymously signs in user -> redirects to /group/roomId
- no api call yet since backend needs endpoints and cors

testing:
- new supabase package in web so make sure to `npm i`

- cannot test on vercel until we set env variables for the deployments, test locally for now:

  - make a web/.env file with VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY variables, i.e. use the same two supabase values as in mobile/.env but change the variable names

  - run web app `npm run dev -w apps/web`

  - in browser navigate to localhost:5173/join?roomId=xxx
    - should redirect user to a group page with mock data
    - you should also see a new anonymous user in the supabase dashboard